### PR TITLE
issue-10: ability to add http client, tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 build:
-	go build -v ./...
+	go build -v .
 
 test:
-	go test -v ./...
+	go test -v .
 
 generate-mocks:
 	mockery -dir=./ -all

--- a/meetup.go
+++ b/meetup.go
@@ -38,18 +38,27 @@ type Clienter interface {
 	DeleteEvent(string) error
 }
 
+// ClientOpts contains options to be passed in when creating a new
+// meetup client value
 type ClientOpts struct {
-	APIKey string
+	APIKey     string
+	HTTPClient *http.Client
 }
 
-// Client
+// Client represents a meetup client
 type Client struct {
 	hc   *http.Client
 	opts *ClientOpts
 }
 
-// NewClient ...
+// NewClient creates a new Meetup client with the given parameters
 func NewClient(opts *ClientOpts) Clienter {
+	if opts.HTTPClient != nil {
+		return &Client{
+			hc:   opts.HTTPClient,
+			opts: opts,
+		}
+	}
 	return &Client{
 		hc: &http.Client{
 			Timeout: time.Duration(time.Second * 20),
@@ -58,7 +67,7 @@ func NewClient(opts *ClientOpts) Clienter {
 	}
 }
 
-// call
+// call acts as a broker for the packages HTTP requests to the meetup.com API
 func (c *Client) call(method, uri string, data *bytes.Buffer, result interface{}) error {
 	var req *http.Request
 

--- a/meetup_test.go
+++ b/meetup_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const apiKey = "asdfasdf12341234"
+
 // validateClientType
 func validateClientType(c Clienter) bool {
 	if _, ok := c.(*Client); !ok {
@@ -12,8 +14,6 @@ func validateClientType(c Clienter) bool {
 	}
 	return true
 }
-
-const apiKey = "asdfasdf12341234"
 
 // TestNewClient
 func TestNewClient(t *testing.T) {

--- a/meetup_test.go
+++ b/meetup_test.go
@@ -1,0 +1,49 @@
+package meetup
+
+import (
+	"net/http"
+	"testing"
+)
+
+// validateClientType
+func validateClientType(c Clienter) bool {
+	if _, ok := c.(*Client); !ok {
+		return false
+	}
+	return true
+}
+
+const apiKey = "asdfasdf12341234"
+
+// TestNewClient
+func TestNewClient(t *testing.T) {
+	copts := ClientOpts{
+		APIKey: apiKey,
+	}
+	c := NewClient(&copts)
+	if !validateClientType(c) {
+		t.Error("returned value NOT of type Clienter")
+	}
+}
+
+// TestNewClient_with_HTTP
+func TestNewClient_with_HTTP(t *testing.T) {
+	copts := ClientOpts{
+		APIKey:     apiKey,
+		HTTPClient: &http.Client{},
+	}
+	c := NewClient(&copts)
+	if !validateClientType(c) {
+		t.Error("returned value NOT of type Clienter")
+	}
+}
+
+// TestNewClient_Nil_Opts
+func TestNewClient_Nil_Opts(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("code never panicked")
+		}
+	}()
+	NewClient(nil)
+}


### PR DESCRIPTION
Resolves #10 

* removed unneeded triple dot notation since there are no subpackages to run tests in.
* add the ability for a user to provide their own HTTP client
* added tests